### PR TITLE
Install all plugins and pixmaps

### DIFF
--- a/gg/meson.build
+++ b/gg/meson.build
@@ -23,5 +23,8 @@ gg_prpl = shared_library('gg',
   'search.c',
   include_directories: toplevel_inc,
   dependencies: [libgadu_dep, libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/gg/pixmaps/meson.build
+++ b/gg/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,8 @@ cfg.set('SIZEOF_TIME_T',
 
 toplevel_inc = include_directories('.')
 
+pixmap_dir = get_option('datadir') / 'pixmaps/pidgin'
+
 subdir('gg')
 subdir('msn')
 subdir('mxit')

--- a/msn/meson.build
+++ b/msn/meson.build
@@ -43,5 +43,8 @@ msn_prpl = shared_library('msn',
   'xfer.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/msn/pixmaps/meson.build
+++ b/msn/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/mxit/meson.build
+++ b/mxit/meson.build
@@ -24,5 +24,8 @@ mxit_prpl = shared_library('mxit',
   'splashscreen.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/mxit/pixmaps/meson.build
+++ b/mxit/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/myspace/meson.build
+++ b/myspace/meson.build
@@ -17,5 +17,8 @@ myspace_prpl = shared_library('myspace',
   'zap.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, math],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/myspace/pixmaps/meson.build
+++ b/myspace/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/novell/meson.build
+++ b/novell/meson.build
@@ -20,5 +20,8 @@ novell_prpl = shared_library('novell',
   'novell.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/novell/pixmaps/meson.build
+++ b/novell/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/oscar/meson.build
+++ b/oscar/meson.build
@@ -49,6 +49,7 @@ if feature.allowed()
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep],
     link_with: liboscar,
+    install: true,
     install_dir: libpurple_dep.get_variable('plugindir'),
   )
 endif
@@ -56,11 +57,14 @@ endif
 feature = get_option('icq')
 summary({'ICQ': feature}, section : 'Protocols')
 if feature.allowed()
-  libicq = static_library('icq',
+  libicq = shared_library('icq',
     'libicq.c',
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep],
     link_with: liboscar,
+    install: true,
     install_dir: libpurple_dep.get_variable('plugindir'),
   )
 endif
+
+subdir('pixmaps')

--- a/oscar/pixmaps/meson.build
+++ b/oscar/pixmaps/meson.build
@@ -1,0 +1,8 @@
+foreach prpl: ['aim', 'icq']
+  if get_option(prpl).allowed()
+    foreach size : [16, 22, 48]
+      install_data(f'protocols/@size@/@prpl@.png', install_dir: pixmap_dir,
+                   preserve_path: true)
+    endforeach
+  endif
+endforeach

--- a/qq/meson.build
+++ b/qq/meson.build
@@ -39,5 +39,8 @@ qq_prpl = shared_library('qq',
   c_args: f'-DQQ_BUDDY_ICON_DIR="@datadir@/pixmaps/purple/buddy_icons/qq"',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/qq/pixmaps/meson.build
+++ b/qq/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/sametime/meson.build
+++ b/sametime/meson.build
@@ -13,5 +13,8 @@ sametime_prpl = shared_library('sametime',
   'sametime.c',
   include_directories: toplevel_inc,
   dependencies: [meanwhile_dep, libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/sametime/pixmaps/meson.build
+++ b/sametime/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/silc/meson.build
+++ b/silc/meson.build
@@ -26,5 +26,8 @@ silc_prpl = shared_library('silc',
   'wb.c',
   include_directories: toplevel_inc,
   dependencies: [silc_dep, libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/silc/pixmaps/meson.build
+++ b/silc/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/silc10/meson.build
+++ b/silc10/meson.build
@@ -26,5 +26,8 @@ silc10_prpl = shared_library('silc10',
   'wb.c',
   include_directories: toplevel_inc,
   dependencies: [silc_dep, libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/silc10/pixmaps/meson.build
+++ b/silc10/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/yahoo/meson.build
+++ b/yahoo/meson.build
@@ -22,6 +22,7 @@ if feature.allowed()
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep],
     link_with: libyahoo,
+    install: true,
     install_dir: libpurple_dep.get_variable('plugindir'),
   )
 endif
@@ -34,6 +35,9 @@ if feature.allowed()
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep],
     link_with: libyahoo,
+    install: true,
     install_dir: libpurple_dep.get_variable('plugindir'),
   )
 endif
+
+subdir('pixmaps')

--- a/yahoo/pixmaps/meson.build
+++ b/yahoo/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)

--- a/zephyr/meson.build
+++ b/zephyr/meson.build
@@ -85,5 +85,8 @@ zephyr_prpl = shared_library('zephyr',
   'zephyr_err.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
+  install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )
+
+subdir('pixmaps')

--- a/zephyr/pixmaps/meson.build
+++ b/zephyr/pixmaps/meson.build
@@ -1,0 +1,1 @@
+install_subdir('protocols', install_dir: pixmap_dir)


### PR DESCRIPTION
Annoyingly, because the purple plugin directory comes from the pkgconfig file, they end up in `/usr` while the pixmaps end up in `/usr/local` since that's the default prefix.

This ends up like this:
```
build/dist/
└── usr
    ├── lib64
    │   └── purple-2
    │       ├── libaim.so
    │       ├── libgg.so
    │       ├── libicq.so
    │       ├── libmsn.so
    │       ├── libmxit.so
    │       ├── libmyspace.so
    │       ├── libnovell.so
    │       ├── libqq.so
    │       ├── libsametime.so
    │       ├── libyahoojp.so
    │       ├── libyahoo.so
    │       └── libzephyr.so
    └── local
        └── share
            └── pixmaps
                └── pidgin
                    └── protocols
                        ├── 16
                        │   ├── aim.png
                        │   ├── gadu-gadu.png
                        │   ├── icq.png
                        │   ├── meanwhile.png
                        │   ├── msn.png
                        │   ├── mxit.png
                        │   ├── myspace.png
                        │   ├── novell.png
                        │   ├── qq.png
                        │   ├── silc.png
                        │   ├── yahoo.png
                        │   └── zephyr.png
                        ├── 22
                        │   ├── aim.png
                        │   ├── gadu-gadu.png
                        │   ├── icq.png
                        │   ├── meanwhile.png
                        │   ├── msn.png
                        │   ├── mxit.png
                        │   ├── myspace.png
                        │   ├── novell.png
                        │   ├── qq.png
                        │   ├── silc.png
                        │   ├── yahoo.png
                        │   └── zephyr.png
                        └── 48
                            ├── aim.png
                            ├── gadu-gadu.png
                            ├── icq.png
                            ├── meanwhile.png
                            ├── msn.png
                            ├── mxit.png
                            ├── myspace.png
                            ├── novell.png
                            ├── qq.png
                            ├── silc.png
                            ├── yahoo.png
                            └── zephyr.png
```