### PR TITLE
Add a use-purple-prefix option

### DIFF
--- a/gg/meson.build
+++ b/gg/meson.build
@@ -24,7 +24,7 @@ gg_prpl = shared_library('gg',
   include_directories: toplevel_inc,
   dependencies: [libgadu_dep, libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,19 @@ cfg.set('SIZEOF_TIME_T',
 
 toplevel_inc = include_directories('.')
 
-pixmap_dir = get_option('datadir') / 'pixmaps/pidgin'
+if get_option('use-purple-prefix')
+  pixmap_dir = libpurple_dep.get_variable('datadir') / 'pixmaps/pidgin'
+  plugin_dir = libpurple_dep.get_variable('plugindir')
+else
+  pixmap_dir = get_option('prefix') / get_option('datadir') / 'pixmaps/pidgin'
+  plugin_dir = get_option('prefix') / get_option('libdir') / 'purple-2'
+endif
+
+summary({
+  'plugins': plugin_dir,
+  'pixmaps': pixmap_dir,
+  },
+  section : 'Install Directories')
 
 subdir('gg')
 subdir('msn')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,7 @@
+option('use-purple-prefix', type : 'boolean', value : true,
+       description : 'Install everything to the purple prefix and plugin directory')
+
+# Protocols
 option('aim', type : 'feature',
        description : 'build the AIM protocol plugin')
 option('gadu-gadu', type : 'feature',

--- a/msn/meson.build
+++ b/msn/meson.build
@@ -44,7 +44,7 @@ msn_prpl = shared_library('msn',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/mxit/meson.build
+++ b/mxit/meson.build
@@ -25,7 +25,7 @@ mxit_prpl = shared_library('mxit',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/myspace/meson.build
+++ b/myspace/meson.build
@@ -18,7 +18,7 @@ myspace_prpl = shared_library('myspace',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, math],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/napster/meson.build
+++ b/napster/meson.build
@@ -11,7 +11,7 @@ napster_prpl = shared_library('napster',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/novell/meson.build
+++ b/novell/meson.build
@@ -21,7 +21,7 @@ novell_prpl = shared_library('novell',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/oscar/meson.build
+++ b/oscar/meson.build
@@ -50,7 +50,7 @@ if feature.allowed()
     dependencies: [libpurple_dep, glib_dep],
     link_with: liboscar,
     install: true,
-    install_dir: libpurple_dep.get_variable('plugindir'),
+    install_dir: plugin_dir,
   )
 endif
 
@@ -63,7 +63,7 @@ if feature.allowed()
     dependencies: [libpurple_dep, glib_dep],
     link_with: liboscar,
     install: true,
-    install_dir: libpurple_dep.get_variable('plugindir'),
+    install_dir: plugin_dir,
   )
 endif
 

--- a/qq/meson.build
+++ b/qq/meson.build
@@ -40,7 +40,7 @@ qq_prpl = shared_library('qq',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/sametime/meson.build
+++ b/sametime/meson.build
@@ -14,7 +14,7 @@ sametime_prpl = shared_library('sametime',
   include_directories: toplevel_inc,
   dependencies: [meanwhile_dep, libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/silc/meson.build
+++ b/silc/meson.build
@@ -27,7 +27,7 @@ silc_prpl = shared_library('silc',
   include_directories: toplevel_inc,
   dependencies: [silc_dep, libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/silc10/meson.build
+++ b/silc10/meson.build
@@ -27,7 +27,7 @@ silc10_prpl = shared_library('silc10',
   include_directories: toplevel_inc,
   dependencies: [silc_dep, libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')

--- a/yahoo/meson.build
+++ b/yahoo/meson.build
@@ -23,7 +23,7 @@ if feature.allowed()
     dependencies: [libpurple_dep, glib_dep],
     link_with: libyahoo,
     install: true,
-    install_dir: libpurple_dep.get_variable('plugindir'),
+    install_dir: plugin_dir,
   )
 endif
 
@@ -36,7 +36,7 @@ if feature.allowed()
     dependencies: [libpurple_dep, glib_dep],
     link_with: libyahoo,
     install: true,
-    install_dir: libpurple_dep.get_variable('plugindir'),
+    install_dir: plugin_dir,
   )
 endif
 

--- a/zephyr/meson.build
+++ b/zephyr/meson.build
@@ -86,7 +86,7 @@ zephyr_prpl = shared_library('zephyr',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep],
   install: true,
-  install_dir: libpurple_dep.get_variable('plugindir'),
+  install_dir: plugin_dir,
 )
 
 subdir('pixmaps')


### PR DESCRIPTION
This will install plugins to the purple plugin directory variable and pixmaps to (purple-prefix)/share/pixmaps if set to true which is the default.

If it is false, plugins goto (libdir)/purple-2 and pixmaps to (datadir)/pidgin.

Fixes #15