### PR TITLE
Add Linux and macOS CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,54 @@
+---
+name: Test building on Linux
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: "Test with ${{ matrix.dependencies }} dependencies"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      matrix:
+        dependencies: ['internal', 'external']
+
+    steps:
+      - name: Prepare build environment
+        run: |
+          sudo apt-get update -yy
+          sudo apt-get install -yy --no-install-recommends \
+            build-essential \
+            libpurple-dev \
+            meson
+
+      - name: Install external dependencies
+        if: matrix.dependencies == 'external'
+        run: |
+          sudo apt-get update -yy
+          sudo apt-get install -yy --no-install-recommends \
+            libgadu-dev \
+            libmeanwhile-dev
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup Meson build
+        run: meson setup build
+
+      - name: Build project
+        run: ninja -C build
+
+      - name: Install build results
+        run: DESTDIR=$PWD/dist ninja -C build install
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: "Linux with ${{ matrix.dependencies }} dependencies"
+          path: ./dist

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,48 @@
+---
+name: Test building on macOS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: "Test with ${{ matrix.dependencies }} dependencies"
+    runs-on: macos-latest
+    permissions:
+      contents: read
+
+    strategy:
+      matrix:
+        dependencies: ['internal', 'external']
+
+    steps:
+      - name: Prepare build environment
+        run: |
+          brew update
+          brew install meson pidgin
+
+      - name: Install external dependencies
+        if: matrix.dependencies == 'external'
+        run: |
+          brew install libgadu
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Setup Meson build
+        run: meson setup build
+
+      - name: Build project
+        run: ninja -C build
+
+      - name: Install build results
+        run: DESTDIR=$PWD/dist ninja -C build install
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: "macOS with ${{ matrix.dependencies }} dependencies"
+          path: ./dist


### PR DESCRIPTION
This builds both with and without external dependencies, then installs to a `dist` directory, and uploads the results as artifacts.

As it builds for `main` and PRs to `main` only, this won't appear here yet, but you can see the latest [Linux results](https://github.com/QuLogic/retro-prpl/actions/runs/15219505547) and [macOS builds](https://github.com/QuLogic/retro-prpl/actions/runs/15219505551) from my fork.

I didn't do Windows because I don't know how to get a Pidgin SDK there.

Fixes #7