### PR TITLE
Fix the build on windows

### DIFF
--- a/gg/meson.build
+++ b/gg/meson.build
@@ -22,7 +22,7 @@ gg_prpl = shared_library('gg',
   'gg-utils.c',
   'search.c',
   include_directories: toplevel_inc,
-  dependencies: [libgadu_dep, libpurple_dep, glib_dep],
+  dependencies: [libgadu_dep, libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,12 @@ else
   plugin_dir = get_option('prefix') / get_option('libdir') / 'purple-2'
 endif
 
+if host_machine.system() == 'windows'
+  ws2_32_dep = cc.find_library('ws2_32')
+else
+  ws2_32_dep = []
+endif
+
 summary({
   'plugins': plugin_dir,
   'pixmaps': pixmap_dir,

--- a/msn/meson.build
+++ b/msn/meson.build
@@ -42,7 +42,7 @@ msn_prpl = shared_library('msn',
   'userlist.c',
   'xfer.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/mxit/meson.build
+++ b/mxit/meson.build
@@ -23,7 +23,7 @@ mxit_prpl = shared_library('mxit',
   'roster.c',
   'splashscreen.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/myspace/meson.build
+++ b/myspace/meson.build
@@ -16,7 +16,7 @@ myspace_prpl = shared_library('myspace',
   'user.c',
   'zap.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep, math],
+  dependencies: [libpurple_dep, glib_dep, math, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/napster/meson.build
+++ b/napster/meson.build
@@ -9,7 +9,7 @@ endif
 napster_prpl = shared_library('napster',
   'napster.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/novell/meson.build
+++ b/novell/meson.build
@@ -19,7 +19,7 @@ novell_prpl = shared_library('novell',
   'nmuserrecord.c',
   'novell.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/oscar/meson.build
+++ b/oscar/meson.build
@@ -38,7 +38,7 @@ liboscar = static_library('oscar',
   'util.c',
   'visibility.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
 )
 
 feature = get_option('aim')
@@ -47,7 +47,7 @@ if feature.allowed()
   libaim = shared_library('aim',
     'libaim.c',
     include_directories: toplevel_inc,
-    dependencies: [libpurple_dep, glib_dep],
+    dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: liboscar,
     install: true,
     install_dir: plugin_dir,
@@ -60,7 +60,7 @@ if feature.allowed()
   libicq = shared_library('icq',
     'libicq.c',
     include_directories: toplevel_inc,
-    dependencies: [libpurple_dep, glib_dep],
+    dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: liboscar,
     install: true,
     install_dir: plugin_dir,

--- a/qq/meson.build
+++ b/qq/meson.build
@@ -38,7 +38,7 @@ qq_prpl = shared_library('qq',
   # concerns, but distributions might want to put icons here.
   c_args: f'-DQQ_BUDDY_ICON_DIR="@datadir@/pixmaps/purple/buddy_icons/qq"',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/sametime/meson.build
+++ b/sametime/meson.build
@@ -12,7 +12,7 @@ meanwhile_dep = dependency('meanwhile', version: ['>= 1.0.0', '< 2.0.0'],
 sametime_prpl = shared_library('sametime',
   'sametime.c',
   include_directories: toplevel_inc,
-  dependencies: [meanwhile_dep, libpurple_dep, glib_dep],
+  dependencies: [meanwhile_dep, libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/silc/meson.build
+++ b/silc/meson.build
@@ -25,7 +25,7 @@ silc_prpl = shared_library('silc',
   'util.c',
   'wb.c',
   include_directories: toplevel_inc,
-  dependencies: [silc_dep, libpurple_dep, glib_dep],
+  dependencies: [silc_dep, libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/silc10/meson.build
+++ b/silc10/meson.build
@@ -25,7 +25,7 @@ silc10_prpl = shared_library('silc10',
   'util.c',
   'wb.c',
   include_directories: toplevel_inc,
-  dependencies: [silc_dep, libpurple_dep, glib_dep],
+  dependencies: [silc_dep, libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )

--- a/toc/meson.build
+++ b/toc/meson.build
@@ -9,7 +9,7 @@ endif
 toc_prpl = shared_library('toc',
   'toc.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: libpurple_dep.get_variable('plugindir'),
 )

--- a/yahoo/meson.build
+++ b/yahoo/meson.build
@@ -11,7 +11,7 @@ libyahoo = static_library('yahoo',
   'yahoo_profile.c',
   'ycht.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
 )
 
 feature = get_option('yahoo')
@@ -20,7 +20,7 @@ if feature.allowed()
   yahoo_prpl = shared_library('yahoo',
     'libyahoo.c',
     include_directories: toplevel_inc,
-    dependencies: [libpurple_dep, glib_dep],
+    dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: libyahoo,
     install: true,
     install_dir: plugin_dir,
@@ -33,7 +33,7 @@ if feature.allowed()
   yahoojp_prpl = shared_library('yahoojp',
     'libyahoojp.c',
     include_directories: toplevel_inc,
-    dependencies: [libpurple_dep, glib_dep],
+    dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: libyahoo,
     install: true,
     install_dir: plugin_dir,

--- a/zephyr/meson.build
+++ b/zephyr/meson.build
@@ -1,8 +1,10 @@
 feature = get_option('zephyr')
 
-summary({'Zephyr': feature}, section : 'Protocols')
+real_feature = feature.disable_auto_if(host_machine.system() == 'windows')
 
-if not feature.allowed()
+summary({'Zephyr': real_feature}, section : 'Protocols')
+
+if not real_feature.allowed()
   subdir_done()
 endif
 
@@ -84,7 +86,7 @@ zephyr_prpl = shared_library('zephyr',
   'zephyr.c',
   'zephyr_err.c',
   include_directories: toplevel_inc,
-  dependencies: [libpurple_dep, glib_dep],
+  dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
   install: true,
   install_dir: plugin_dir,
 )


### PR DESCRIPTION
This is mostly just looking for winsock and adding it as a dependency to everything, but it also disables zephyr on Windows as it doesn't look like that was ever supported.