### PR TITLE
Disable internal libgadu deprecations

### DIFF
--- a/gg/lib/meson.build
+++ b/gg/lib/meson.build
@@ -26,6 +26,7 @@ libgadu = static_library('libgadu',
   'sha1.c',
   'tvbuff.c',
   'tvbuilder.c',
+  c_args: '-DGG_IGNORE_DEPRECATED',
   include_directories: [libgadu_inc, toplevel_inc],
   dependencies: zlib_dep,
 )


### PR DESCRIPTION
We aren't developing libgadu, so don't need to see these deprecations, and I assume they're supposed to be for external users, such as the prpl (which keeps the deprecations on.)