### PR TITLE
Make ALERT use the right SNAC subtype

### DIFF
--- a/oscar/family_alert.c
+++ b/oscar/family_alert.c
@@ -189,7 +189,7 @@ aim_email_activate(OscarData *od)
 	byte_stream_put32(&bs, 0x00000000);
 
 	snacid = aim_cachesnac(od, SNAC_FAMILY_ALERT, 0x0016, 0x0000, NULL, 0);
-	flap_connection_send_snac(od, conn, SNAC_FAMILY_ALERT, 0x0006, snacid, &bs);
+	flap_connection_send_snac(od, conn, SNAC_FAMILY_ALERT, 0x0016, snacid, &bs);
 
 	byte_stream_destroy(&bs);
 


### PR DESCRIPTION
The ALERT family handler was sending the wrong SNAC subtype (0x0006 instead of 0x0016). 