### PR TITLE
Use .so as the suffix on macOS

### DIFF
--- a/gg/meson.build
+++ b/gg/meson.build
@@ -23,6 +23,7 @@ gg_prpl = shared_library('gg',
   'search.c',
   include_directories: toplevel_inc,
   dependencies: [libgadu_dep, libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,11 @@ else
   ws2_32_dep = []
 endif
 
+plugin_suffix = []
+if host_machine.system() == 'darwin'
+  plugin_suffix = 'so'
+endif
+
 summary({
   'plugins': plugin_dir,
   'pixmaps': pixmap_dir,

--- a/msn/meson.build
+++ b/msn/meson.build
@@ -43,6 +43,7 @@ msn_prpl = shared_library('msn',
   'xfer.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/mxit/meson.build
+++ b/mxit/meson.build
@@ -24,6 +24,7 @@ mxit_prpl = shared_library('mxit',
   'splashscreen.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/myspace/meson.build
+++ b/myspace/meson.build
@@ -17,6 +17,7 @@ myspace_prpl = shared_library('myspace',
   'zap.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, math, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/napster/meson.build
+++ b/napster/meson.build
@@ -10,6 +10,7 @@ napster_prpl = shared_library('napster',
   'napster.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/novell/meson.build
+++ b/novell/meson.build
@@ -20,6 +20,7 @@ novell_prpl = shared_library('novell',
   'novell.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/oscar/meson.build
+++ b/oscar/meson.build
@@ -49,6 +49,7 @@ if feature.allowed()
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: liboscar,
+    name_suffix: plugin_suffix,
     install: true,
     install_dir: plugin_dir,
   )
@@ -62,6 +63,7 @@ if feature.allowed()
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: liboscar,
+    name_suffix: plugin_suffix,
     install: true,
     install_dir: plugin_dir,
   )

--- a/qq/meson.build
+++ b/qq/meson.build
@@ -39,6 +39,7 @@ qq_prpl = shared_library('qq',
   c_args: f'-DQQ_BUDDY_ICON_DIR="@datadir@/pixmaps/purple/buddy_icons/qq"',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/sametime/meson.build
+++ b/sametime/meson.build
@@ -13,6 +13,7 @@ sametime_prpl = shared_library('sametime',
   'sametime.c',
   include_directories: toplevel_inc,
   dependencies: [meanwhile_dep, libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/silc/meson.build
+++ b/silc/meson.build
@@ -26,6 +26,7 @@ silc_prpl = shared_library('silc',
   'wb.c',
   include_directories: toplevel_inc,
   dependencies: [silc_dep, libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/silc10/meson.build
+++ b/silc10/meson.build
@@ -26,6 +26,7 @@ silc10_prpl = shared_library('silc10',
   'wb.c',
   include_directories: toplevel_inc,
   dependencies: [silc_dep, libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/toc/meson.build
+++ b/toc/meson.build
@@ -10,6 +10,7 @@ toc_prpl = shared_library('toc',
   'toc.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )

--- a/yahoo/meson.build
+++ b/yahoo/meson.build
@@ -22,6 +22,7 @@ if feature.allowed()
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: libyahoo,
+    name_suffix: plugin_suffix,
     install: true,
     install_dir: plugin_dir,
   )
@@ -35,6 +36,7 @@ if feature.allowed()
     include_directories: toplevel_inc,
     dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
     link_with: libyahoo,
+    name_suffix: plugin_suffix,
     install: true,
     install_dir: plugin_dir,
   )

--- a/zephyr/meson.build
+++ b/zephyr/meson.build
@@ -87,6 +87,7 @@ zephyr_prpl = shared_library('zephyr',
   'zephyr_err.c',
   include_directories: toplevel_inc,
   dependencies: [libpurple_dep, glib_dep, ws2_32_dep],
+  name_suffix: plugin_suffix,
   install: true,
   install_dir: plugin_dir,
 )


### PR DESCRIPTION
Purple 2 looks for plugins with a .so suffix on macOS and not .dylib. So without this, the plugins are ignored unless they're renamed.

Fixes #30