### PR TITLE
Use the result of `g_string_free(..., FALSE)` in older prpls

### DIFF
--- a/qq/im.c
+++ b/qq/im.c
@@ -454,7 +454,6 @@ static gchar *emoticon_get(guint8 symbol)
    Notice: text is in qq charset, GB18030 or utf8 */
 gchar *qq_emoticon_to_purple(gchar *text)
 {
-	gchar *ret;
 	GString *converted;
 	gchar **segments;
 	gboolean have_smiley;
@@ -511,9 +510,7 @@ gchar *qq_emoticon_to_purple(gchar *text)
 		g_string_prepend(converted, "<font sml=\"none\">");
 		g_string_append(converted, "</font>");
 	}
-	ret = converted->str;
-	g_string_free(converted, FALSE);
-	return ret;
+	return g_string_free(converted, FALSE);
 }
 
 void qq_im_fmt_free(qq_im_format *fmt)
@@ -614,7 +611,6 @@ qq_im_format *qq_im_fmt_new_by_purple(const gchar *msg)
 gchar *qq_im_fmt_to_purple(qq_im_format *fmt, gchar *text)
 {
 	GString *converted, *tmp;
-	gchar *ret;
 	gint size;
 
 	converted = g_string_new(text);
@@ -658,9 +654,7 @@ gchar *qq_im_fmt_to_purple(qq_im_format *fmt, gchar *text)
 	}
 
 	g_string_free(tmp, TRUE);
-	ret = converted->str;
-	g_string_free(converted, FALSE);
-	return ret;
+	return g_string_free(converted, FALSE);
 }
 
 gint qq_put_im_tail(guint8 *buf, qq_im_format *fmt)

--- a/qq/qq_process.c
+++ b/qq/qq_process.c
@@ -200,8 +200,7 @@ static void do_msg_sys_4c(PurpleConnection *gc, guint8 *data, gint data_len)
 		purple_debug_warning("QQ", "Failed to read QQ_MSG_SYS_4C\n");
 		qq_show_packet("do_msg_sys_4c", data, data_len);
 	}
-	qq_got_message(gc, content->str);
-	g_string_free(content, FALSE);
+	qq_got_message(gc, g_string_free(content, FALSE));
 }
 
 static const gchar *get_im_type_desc(gint type)

--- a/qq/utils.c
+++ b/qq/utils.c
@@ -203,7 +203,7 @@ gchar* try_dump_as_gbk(const guint8 *const data, gint len)
 static gchar *strstrip(const gchar *const buffer)
 {
 	GString *stripped;
-	gchar *ret, cur;
+	gchar cur;
 	gint i;
 
 	g_return_val_if_fail(buffer != NULL, NULL);
@@ -214,10 +214,8 @@ static gchar *strstrip(const gchar *const buffer)
 		if (cur != ' ' && cur != '\n')
 			g_string_append_c(stripped, buffer[i]);
 	}
-	ret = stripped->str;
-	g_string_free(stripped, FALSE);
 
-	return ret;
+	return g_string_free(stripped, FALSE);
 }
 
 /* Attempts to dump an ASCII hex string to a string of bytes.
@@ -281,7 +279,6 @@ guint8 *hex_str_to_bytes(const gchar *const buffer, gint *out_len)
 static gchar *hex_dump_to_str(const guint8 *const buffer, gint bytes)
 {
 	GString *str;
-	gchar *ret;
 	gint i, j, ch;
 
 	str = g_string_new("");
@@ -308,11 +305,7 @@ static gchar *hex_dump_to_str(const guint8 *const buffer, gint bytes)
 		g_string_append_c(str, '\n');
 	}
 
-	ret = str->str;
-	/* GString can be freed without freeing it character data */
-	g_string_free(str, FALSE);
-
-	return ret;
+	return g_string_free(str, FALSE);
 }
 
 void qq_hex_dump(PurpleDebugLevel level, const char *category,

--- a/silc10/chat.c
+++ b/silc10/chat.c
@@ -92,7 +92,7 @@ silcpurple_chat_getinfo(PurpleConnection *gc, GHashTable *components)
 {
 	SilcPurple sg = gc->proto_data;
 	const char *chname;
-	char *buf, tmp[256], *tmp2;
+	char tmp[256], *tmp2;
 	GString *s;
 	SilcChannelEntry channel;
 	SilcHashTableList htl;
@@ -170,9 +170,8 @@ silcpurple_chat_getinfo(PurpleConnection *gc, GHashTable *components)
 		silc_free(pk);
 	}
 
-	buf = g_string_free(s, FALSE);
-	purple_notify_formatted(gc, NULL, _("Channel Information"), NULL, buf, NULL, NULL);
-	g_free(buf);
+	purple_notify_formatted(gc, NULL, _("Channel Information"), NULL, s->str, NULL, NULL);
+	g_string_free(s, TRUE);
 }
 
 

--- a/silc10/ops.c
+++ b/silc10/ops.c
@@ -995,7 +995,6 @@ silcpurple_whois_more(SilcClientEntry client_entry, gint id)
 {
 	SilcAttributePayload attr;
 	SilcAttribute attribute;
-	char *buf;
 	GString *s;
 	SilcVCardStruct vcard;
 	int i;
@@ -1085,10 +1084,9 @@ silcpurple_whois_more(SilcClientEntry client_entry, gint id)
 		}
 	}
 
-	buf = g_string_free(s, FALSE);
 	purple_notify_info(NULL, _("User Information"), _("User Information"),
-			 buf);
-	g_free(buf);
+			 s->str);
+	g_string_free(s, TRUE);
 }
 #endif
 

--- a/silc10/util.c
+++ b/silc10/util.c
@@ -332,7 +332,6 @@ void silcpurple_show_public_key(SilcPurple sg,
 	unsigned char *pk;
 	SilcUInt32 pk_len, key_len = 0;
 	GString *s;
-	char *buf;
 
 	ident = silc_pkcs_decode_identifier(public_key->identifier);
 	if (!ident)
@@ -369,14 +368,12 @@ void silcpurple_show_public_key(SilcPurple sg,
 	g_string_append_printf(s, _("Public Key Fingerprint:\n%s\n\n"), fingerprint);
 	g_string_append_printf(s, _("Public Key Babbleprint:\n%s"), babbleprint);
 
-	buf = g_string_free(s, FALSE);
-
 	purple_request_action(sg->gc, _("Public Key Information"),
 			    _("Public Key Information"),
-			    buf, 0, purple_connection_get_account(sg->gc),
+			    s->str, 0, purple_connection_get_account(sg->gc),
 				NULL, NULL, context, 1, _("Close"), callback);
 
-	g_free(buf);
+	g_string_free(s, TRUE);
 	silc_free(fingerprint);
 	silc_free(babbleprint);
 	silc_free(pk);

--- a/yahoo/util.c
+++ b/yahoo/util.c
@@ -784,8 +784,7 @@ static void parse_font_tag(GString *dest, const char *tag_name, const char *tag,
 		*tags = g_slist_prepend(*tags, g_strdup("</font>"));
 		g_string_free(tmp, TRUE);
 	} else {
-		*tags = g_slist_prepend(*tags, tmp->str);
-		g_string_free(tmp, FALSE);
+		*tags = g_slist_prepend(*tags, g_string_free(tmp, FALSE));
 	}
 
 	g_datalist_clear(&attributes);


### PR DESCRIPTION
Thus silencing the warnings about unused results.