### PR TITLE
Switch `g_memdup` to `g_memdup2`

### DIFF
--- a/msn/cmdproc.c
+++ b/msn/cmdproc.c
@@ -172,7 +172,7 @@ msn_cmdproc_process_payload(MsnCmdProc *cmdproc, char *payload,
 	g_return_if_fail(cmdproc != NULL);
 
 	last = cmdproc->last_cmd;
-	last->payload = g_memdup(payload, payload_len);
+	last->payload = g_memdup2(payload, payload_len);
 	last->payload_len = payload_len;
 
 	if (last->payload_cb != NULL)

--- a/msn/httpconn.c
+++ b/msn/httpconn.c
@@ -522,7 +522,7 @@ msn_httpconn_write(MsnHttpConn *httpconn, const char *body, size_t body_len)
 		MsnHttpQueueData *queue_data = g_new0(MsnHttpQueueData, 1);
 
 		queue_data->httpconn = httpconn;
-		queue_data->body     = g_memdup(body, body_len);
+		queue_data->body     = g_memdup2(body, body_len);
 		queue_data->body_len = body_len;
 
 		httpconn->queue = g_list_append(httpconn->queue, queue_data);

--- a/msn/msn.c
+++ b/msn/msn.c
@@ -2777,7 +2777,7 @@ msn_got_photo(PurpleUtilFetchUrlData *url_data, gpointer user_data,
 		{
 			char buf[1024];
 			purple_debug_info("msn", "%s is %" G_GSIZE_FORMAT " bytes\n", photo_url_text, len);
-			id = purple_imgstore_add_with_id(g_memdup(url_text, len), len, NULL);
+			id = purple_imgstore_add_with_id(g_memdup2(url_text, len), len, NULL);
 			g_snprintf(buf, sizeof(buf), "<img id=\"%d\"><br>", id);
 			purple_notify_user_info_prepend_pair(user_info, NULL, buf);
 		}

--- a/msn/servconn.c
+++ b/msn/servconn.c
@@ -500,7 +500,7 @@ MsnServConn *msn_servconn_process_data(MsnServConn *servconn)
 	if (servconn->connected && !servconn->wasted)
 	{
 		if (servconn->rx_len > 0)
-			servconn->rx_buf = g_memdup(cur, servconn->rx_len);
+			servconn->rx_buf = g_memdup2(cur, servconn->rx_len);
 		else
 			servconn->rx_buf = NULL;
 	}

--- a/msn/slp.c
+++ b/msn/slp.c
@@ -130,7 +130,7 @@ got_user_display(MsnSlpCall *slpcall,
 	account = slpcall->slplink->session->account;
 
 	purple_buddy_icons_set_for_user(account, slpcall->slplink->remote_user,
-								  g_memdup(data, size), size, info);
+								  g_memdup2(data, size), size, info);
 }
 
 static void
@@ -180,7 +180,7 @@ fetched_user_display(PurpleUtilFetchUrlData *url_data, gpointer user_data,
 
 	if (url_text) {
 		purple_buddy_icons_set_for_user(session->account, data->remote_user,
-		                                g_memdup(url_text, len), len,
+		                                g_memdup2(url_text, len), len,
 		                                data->sha1);
 	}
 
@@ -213,7 +213,7 @@ request_own_user_display(MsnUser *user)
 		info = msn_object_get_sha1(my_obj);
 	}
 
-	purple_buddy_icons_set_for_user(account, user->passport, g_memdup(data, len), len, info);
+	purple_buddy_icons_set_for_user(account, user->passport, g_memdup2(data, len), len, info);
 
 	/* Free one window slot */
 	session->userlist->buddy_icon_window++;

--- a/msn/slpmsg.c
+++ b/msn/slpmsg.c
@@ -117,7 +117,7 @@ msn_slpmsg_set_body(MsnSlpMessage *slpmsg, const char *body,
 	g_return_if_fail(slpmsg->ft == FALSE);
 
 	if (body != NULL)
-		slpmsg->buffer = g_memdup(body, size);
+		slpmsg->buffer = g_memdup2(body, size);
 	else
 		slpmsg->buffer = g_new0(guchar, size);
 

--- a/msn/tlv.c
+++ b/msn/tlv.c
@@ -82,7 +82,7 @@ msn_tlvlist_read(const char *bs, size_t bs_len)
 
 		tlv = createtlv(type, length, NULL);
 		if (length > 0) {
-			tlv->value = g_memdup(bs, length);
+			tlv->value = g_memdup2(bs, length);
 			if (!tlv->value) {
 				freetlv(tlv);
 				msn_tlvlist_free(list);
@@ -178,7 +178,7 @@ msn_tlvlist_add_raw(GSList **list, const guint8 type, const guint8 length, const
 
 	tlv = createtlv(type, length, NULL);
 	if (length > 0)
-		tlv->value = g_memdup(value, length);
+		tlv->value = g_memdup2(value, length);
 
 	*list = g_slist_append(*list, tlv);
 
@@ -255,7 +255,7 @@ msn_tlvlist_replace_raw(GSList **list, const guint8 type, const guint8 length, c
 	g_free(tlv->value);
 	tlv->length = length;
 	if (length > 0) {
-		tlv->value = g_memdup(value, length);
+		tlv->value = g_memdup2(value, length);
 	} else
 		tlv->value = NULL;
 

--- a/msn/xfer.c
+++ b/msn/xfer.c
@@ -224,7 +224,7 @@ msn_file_context_from_wire(const char *buf, gsize len)
 
 	if (context->type == 0 && len > context->length) {
 		context->preview_len = len - context->length;
-		context->preview = g_memdup(buf, context->preview_len);
+		context->preview = g_memdup2(buf, context->preview_len);
 	} else {
 		context->preview_len = 0;
 		context->preview = NULL;

--- a/mxit/formcmds.c
+++ b/mxit/formcmds.c
@@ -104,7 +104,7 @@ static void mxit_cb_ii_returned(PurpleUtilFetchUrlData* url_data, gpointer user_
 	}
 
 	/* we now have the inline image, store a copy in the imagestore */
-	id = purple_imgstore_add_with_id(g_memdup(url_text, len), len, NULL);
+	id = purple_imgstore_add_with_id(g_memdup2(url_text, len), len, NULL);
 
 	/* map the inline image id to purple image id */
 	intptr = g_malloc(sizeof(int));

--- a/mxit/protocol.c
+++ b/mxit/protocol.c
@@ -2240,13 +2240,13 @@ static void mxit_parse_cmd_media( struct MXitSession* session, struct record** r
 					contact = get_mxit_invite_contact( session, chunk.mxitid );
 					if ( contact ) {
 						/* this is an invite (add image to the internal image store) */
-						contact->imgid = purple_imgstore_add_with_id( g_memdup( chunk.data, chunk.length ), chunk.length, NULL );
+						contact->imgid = purple_imgstore_add_with_id( g_memdup2( chunk.data, chunk.length ), chunk.length, NULL );
 						/* show the profile */
 						mxit_show_profile( session, chunk.mxitid, contact->profile );
 					}
 					else {
 						/* this is a contact's avatar, so update it */
-						purple_buddy_icons_set_for_user( session->acc, chunk.mxitid, g_memdup( chunk.data, chunk.length ), chunk.length, chunk.avatarid );
+						purple_buddy_icons_set_for_user( session->acc, chunk.mxitid, g_memdup2( chunk.data, chunk.length ), chunk.length, chunk.avatarid );
 					}
 				}
 			}

--- a/mxit/splashscreen.c
+++ b/mxit/splashscreen.c
@@ -184,7 +184,7 @@ void splash_display(struct MXitSession* session)
 		char buf[128];
 
 		/* Add splash-image to imagestore */
-		imgid = purple_imgstore_add_with_id(g_memdup(imgdata, imglen), imglen, NULL);
+		imgid = purple_imgstore_add_with_id(g_memdup2(imgdata, imglen), imglen, NULL);
 
 		/* Generate and display message */
 		g_snprintf(buf, sizeof(buf), "<img id=\"%d\">", imgid);

--- a/myspace/message.c
+++ b/myspace/message.c
@@ -1371,7 +1371,7 @@ msim_msg_get_binary_from_element(MsimMessageElement *elem, gchar **binary_data, 
 			gs = (GString *)elem->data;
 
 			/* Duplicate data, so caller can g_free() it. */
-			*binary_data = g_memdup(gs->str, gs->len);
+			*binary_data = g_memdup2(gs->str, gs->len);
 			*binary_length = gs->len;
 
 			return TRUE;

--- a/myspace/user.c
+++ b/myspace/user.c
@@ -228,7 +228,7 @@ msim_downloaded_buddy_icon(PurpleUtilFetchUrlData *url_data,
 
 	account = purple_buddy_get_account(user->buddy);
 	purple_buddy_icons_set_for_user(account, name,
-			g_memdup((gchar *)url_text, len), len,
+			g_memdup2((gchar *)url_text, len), len,
 			/* Use URL itself as buddy icon "checksum" (TODO: ETag) */
 			user->image_url);		/* checksum */
 }

--- a/qq/qq_network.c
+++ b/qq/qq_network.c
@@ -461,7 +461,7 @@ static void tcp_pending(gpointer data, gint source, PurpleInputCondition cond)
 		conn->tcp_rxlen -= pkt_len;
 		if (conn->tcp_rxlen) {
 			/* purple_debug_info("TCP_PENDING", "shrink tcp_rxqueue to %d\n", conn->tcp_rxlen);	*/
-			jump = g_memdup(conn->tcp_rxqueue + pkt_len, conn->tcp_rxlen);
+			jump = g_memdup2(conn->tcp_rxqueue + pkt_len, conn->tcp_rxlen);
 			g_free(conn->tcp_rxqueue);
 			conn->tcp_rxqueue = jump;
 		} else {

--- a/qq/qq_trans.c
+++ b/qq/qq_trans.c
@@ -105,7 +105,7 @@ static qq_transaction *trans_create(PurpleConnection *gc, gint fd,
 	trans->data_len = 0;
 	if (data != NULL && data_len > 0) {
 		/* don't use g_strdup, may have 0x00 */
-		trans->data = g_memdup(data, data_len);
+		trans->data = g_memdup2(data, data_len);
 		trans->data_len = data_len;
 	}
 
@@ -248,7 +248,7 @@ void qq_trans_add_server_reply(PurpleConnection *gc, guint16 cmd, guint16 seq,
 
 	if (trans->data)	g_free(trans->data);
 
-	trans->data = g_memdup(reply, reply_len);
+	trans->data = g_memdup2(reply, reply_len);
 	trans->data_len = reply_len;
 }
 

--- a/qq/utils.c
+++ b/qq/utils.c
@@ -273,7 +273,7 @@ guint8 *hex_str_to_bytes(const gchar *const buffer, gint *out_len)
 	}
 	*out_len = strlen(hex_str) / 2;
 	g_free(hex_str);
-	return g_memdup(bytes, *out_len);
+	return g_memdup2(bytes, *out_len);
 }
 
 /* Dumps a chunk of raw data into an ASCII hex string.

--- a/yahoo/libymsg.c
+++ b/yahoo/libymsg.c
@@ -3427,7 +3427,7 @@ static void yahoo_pending(gpointer data, gint source, PurpleInputCondition cond)
 
 		yd->rxlen -= YAHOO_PACKET_HDRLEN + pktlen;
 		if (yd->rxlen) {
-			guchar *tmp = g_memdup(yd->rxqueue + YAHOO_PACKET_HDRLEN + pktlen, yd->rxlen);
+			guchar *tmp = g_memdup2(yd->rxqueue + YAHOO_PACKET_HDRLEN + pktlen, yd->rxlen);
 			g_free(yd->rxqueue);
 			yd->rxqueue = tmp;
 		} else {

--- a/yahoo/yahoo_picture.c
+++ b/yahoo/yahoo_picture.c
@@ -61,7 +61,7 @@ yahoo_fetch_picture_cb(PurpleUtilFetchUrlData *url_data, gpointer user_data,
 		purple_debug_error("yahoo", "Fetched an icon with length 0.  Strange.\n");
 	} else {
 		char *checksum = g_strdup_printf("%i", d->checksum);
-		purple_buddy_icons_set_for_user(purple_connection_get_account(d->gc), d->who, g_memdup(pic_data, len), len, checksum);
+		purple_buddy_icons_set_for_user(purple_connection_get_account(d->gc), d->who, g_memdup2(pic_data, len), len, checksum);
 		g_free(checksum);
 	}
 

--- a/yahoo/yahoo_profile.c
+++ b/yahoo/yahoo_profile.c
@@ -1045,7 +1045,7 @@ yahoo_got_photo(PurpleUtilFetchUrlData *url_data, gpointer data,
 		} else {
 			purple_debug_info("yahoo", "%s is %" G_GSIZE_FORMAT
 					" bytes\n", photo_url_text, len);
-			id = purple_imgstore_add_with_id(g_memdup(url_text, len), len, NULL);
+			id = purple_imgstore_add_with_id(g_memdup2(url_text, len), len, NULL);
 
 			tmp = g_strdup_printf("<img id=\"%d\"><br>", id);
 			purple_notify_user_info_add_pair(user_info, NULL, tmp);

--- a/yahoo/ycht.c
+++ b/yahoo/ycht.c
@@ -523,7 +523,7 @@ static void ycht_pending(gpointer data, gint source, PurpleInputCondition cond)
 
 		ycht->rxlen -= YCHT_HEADER_LEN + pktlen;
 		if (ycht->rxlen) {
-			guchar *tmp = g_memdup(ycht->rxqueue + YCHT_HEADER_LEN + pktlen, ycht->rxlen);
+			guchar *tmp = g_memdup2(ycht->rxqueue + YCHT_HEADER_LEN + pktlen, ycht->rxlen);
 			g_free(ycht->rxqueue);
 			ycht->rxqueue = tmp;
 		} else {


### PR DESCRIPTION
The latter is already used in the prpls that were not deleted so early, due to 669c68d92b0486823138deb3a8062f80308da2af. An inline version is provided by libpurple's `glibcompat.h` if necessary, and included by `internal.h` here.