### PR TITLE
Replace g_memmove by memmove

### DIFF
--- a/msn/directconn.c
+++ b/msn/directconn.c
@@ -686,7 +686,7 @@ msn_dc_recv_cb(gpointer data, gint fd, PurpleInputCondition cond)
 		}
 
 		if ((guint32)dc->in_pos > packet_length + 4) {
-			g_memmove(dc->in_buffer, dc->in_buffer + 4 + packet_length, dc->in_pos - packet_length - 4);
+			memmove(dc->in_buffer, dc->in_buffer + 4 + packet_length, dc->in_pos - packet_length - 4);
 		}
 
 		dc->in_pos -= packet_length + 4;

--- a/qq/buddy_list.c
+++ b/qq/buddy_list.c
@@ -338,7 +338,7 @@ guint16 qq_process_get_buddies(guint8 *data, gint data_len, PurpleConnection *gc
 		bd.last_update = time(NULL);
 		qq_update_buddy_status(gc, bd.uid, bd.status, bd.comm_flag);
 
-		g_memmove(purple_buddy_get_protocol_data(buddy), &bd, sizeof(qq_buddy_data));
+		memmove(purple_buddy_get_protocol_data(buddy), &bd, sizeof(qq_buddy_data));
 		/* nickname has been copy to buddy_data do not free
 		   g_free(bd.nickname);
 		*/

--- a/qq/buddy_opt.c
+++ b/qq/buddy_opt.c
@@ -657,7 +657,7 @@ void add_buddy_authorize_input(PurpleConnection *gc, UID uid,
 	add_req->auth_len = 0;
 	if (auth != NULL && auth_len > 0) {
 		add_req->auth = g_new0(guint8, auth_len);
-		g_memmove(add_req->auth, auth, auth_len);
+		memmove(add_req->auth, auth, auth_len);
 		add_req->auth_len = auth_len;
 	}
 

--- a/qq/im.c
+++ b/qq/im.c
@@ -580,7 +580,7 @@ qq_im_format *qq_im_fmt_new_by_purple(const gchar *msg)
 			gsize rgb_len;
 			rgb = purple_base16_decode(tmp + 1, &rgb_len);
 			if (rgb != NULL && rgb_len >= 3)
-				g_memmove(fmt->rgb, rgb, 3);
+				memmove(fmt->rgb, rgb, 3);
 			g_free(rgb);
 		}
 

--- a/qq/qq_base.c
+++ b/qq/qq_base.c
@@ -340,7 +340,7 @@ guint8 qq_process_token(PurpleConnection *gc, guint8 *buf, gint buf_len)
 	}
 	qd->ld.token = g_new0(guint8, token_len);
 	qd->ld.token_len = token_len;
-	g_memmove(qd->ld.token, buf + 2, qd->ld.token_len);
+	memmove(qd->ld.token, buf + 2, qd->ld.token_len);
 	return ret;
 }
 
@@ -857,7 +857,7 @@ void qq_captcha_input_dialog(PurpleConnection *gc,qq_captcha_data *captcha)
 	captcha_req = g_new0(qq_captcha_request, 1);
 	captcha_req->gc = gc;
 	captcha_req->token = g_new0(guint8, captcha->token_len);
-	g_memmove(captcha_req->token, captcha->token, captcha->token_len);
+	memmove(captcha_req->token, captcha->token, captcha->token_len);
 	captcha_req->token_len = captcha->token_len;
 
 	account = purple_connection_get_account(gc);

--- a/qq/qq_crypt.c
+++ b/qq/qq_crypt.c
@@ -147,7 +147,7 @@ static inline void encrypt_out(guint8 *crypted, const gint crypted_len, const gu
 	p32_prev[0] = 0; p32_prev[1] = 0;
 	plain32[0] = crypted32[0] ^ p32_prev[0]; plain32[1] = crypted32[1] ^ p32_prev[1];
 
-	g_memmove(key32, key, 16);
+	memmove(key32, key, 16);
 	count64 = crypted_len / 8;
 	while (count64-- > 0){
 		/* encrypt it */
@@ -156,7 +156,7 @@ static inline void encrypt_out(guint8 *crypted, const gint crypted_len, const gu
 		crypted32[0] ^= p32_prev[0]; crypted32[1] ^= p32_prev[1];
 
 		/* store curr 64 bits crypted */
-		g_memmove(crypted_ptr, crypted32, sizeof(crypted32));
+		memmove(crypted_ptr, crypted32, sizeof(crypted32));
 
 		/* set prev */
 		p32_prev[0] = plain32[0]; p32_prev[1] = plain32[1];
@@ -206,7 +206,7 @@ gint qq_encrypt(guint8* crypted, const guint8* const plain, const gint plain_len
 		crypted_ptr[pos++] = rand() & 0xff;
 	}
 
-	g_memmove(crypted_ptr + pos, plain, plain_len);
+	memmove(crypted_ptr + pos, plain, plain_len);
 	pos += plain_len;
 
 	/* header padding len + plain len must be multiple of 8
@@ -330,7 +330,7 @@ gint qq_decrypt(guint8 *plain, const guint8* const crypted, const gint crypted_l
 	}
 
 	hdr_padding = crypted_len - plain_len - 7;
-	g_memmove(plain, plain + hdr_padding, plain_len);
+	memmove(plain, plain + hdr_padding, plain_len);
 
 	return plain_len;
 }

--- a/qq/qq_network.c
+++ b/qq/qq_network.c
@@ -449,13 +449,13 @@ static void tcp_pending(gpointer data, gint source, PurpleInputCondition cond)
 			/* jump and over QQ_PACKET_TAIL */
 			jump_len = (jump - conn->tcp_rxqueue) + 1;
 			purple_debug_warning("TCP_PENDING", "Find next tail at %d, jump %d\n", jump_len, jump_len + 1);
-			g_memmove(conn->tcp_rxqueue, jump, conn->tcp_rxlen - jump_len);
+			memmove(conn->tcp_rxqueue, jump, conn->tcp_rxlen - jump_len);
 			conn->tcp_rxlen -= jump_len;
 			continue;
 		}
 
 		memset(pkt, 0, MAX_PACKET_SIZE);
-		g_memmove(pkt, conn->tcp_rxqueue + bytes, pkt_len - bytes);
+		memmove(pkt, conn->tcp_rxqueue + bytes, pkt_len - bytes);
 
 		/* jump to next packet */
 		conn->tcp_rxlen -= pkt_len;

--- a/qq/qq_process.c
+++ b/qq/qq_process.c
@@ -435,7 +435,7 @@ static void process_server_msg(PurpleConnection *gc, guint8 *data, gint data_len
 	qd = (qq_data *) gc->proto_data;
 
 	data_str = g_newa(guint8, data_len + 1);
-	g_memmove(data_str, data, data_len);
+	memmove(data_str, data, data_len);
 	data_str[data_len] = 0x00;
 
 	segments = g_strsplit((gchar *) data_str, "\x1f", 0);

--- a/qq/send_file.c
+++ b/qq/send_file.c
@@ -807,11 +807,11 @@ void qq_process_recv_file_request(guint8 *data, gint data_len, UID sender_uid, P
 		bd = (b == NULL) ? NULL : purple_buddy_get_protocol_data(b);
 		if (bd) {
 			if(0 != info->remote_real_ip) {
-				g_memmove(&(bd->ip), &info->remote_real_ip, sizeof(bd->ip));
+				memmove(&(bd->ip), &info->remote_real_ip, sizeof(bd->ip));
 				bd->port = info->remote_minor_port;
 			}
 			else if (0 != info->remote_internet_ip) {
-				g_memmove(&(bd->ip), &info->remote_internet_ip, sizeof(bd->ip));
+				memmove(&(bd->ip), &info->remote_internet_ip, sizeof(bd->ip));
 				bd->port = info->remote_major_port;
 			}
 

--- a/qq/utils.c
+++ b/qq/utils.c
@@ -105,7 +105,7 @@ gchar **split_data(guint8 *data, gint len, const gchar *delimit, gint expected_f
 	/* as the last field would be string, but data is not ended with 0x00
 	 * we have to duplicate the data and append a 0x00 at the end */
 	input = g_newa(guint8, len + 1);
-	g_memmove(input, data, len);
+	memmove(input, data, len);
 	input[len] = 0x00;
 
 	segments = g_strsplit((gchar *) input, delimit, 0);
@@ -181,7 +181,7 @@ gchar* try_dump_as_gbk(const guint8 *const data, gint len)
 	gchar *msg_utf8;
 
 	incoming = g_newa(guint8, len + 1);
-	g_memmove(incoming, data, len);
+	memmove(incoming, data, len);
 	incoming[len] = 0x00;
 	/* GBK code:
 	 * Single-byte ASCII:      0x21-0x7E

--- a/yahoo/libymsg.c
+++ b/yahoo/libymsg.c
@@ -2753,7 +2753,7 @@ static void yahoo_p2p_read_pkt_cb(gpointer data, gint source, PurpleInputConditi
 		purple_debug_warning("yahoo","p2p: Got something other than YMSG packet\n");
 
 		len -= (start - buf);
-		g_memmove(buf, start, len);
+		memmove(buf, start, len);
 	}
 
 	pos += 4;	/* YMSG */
@@ -3392,7 +3392,7 @@ static void yahoo_pending(gpointer data, gint source, PurpleInputCondition cond)
 
 			start = memchr(yd->rxqueue + 1, 'Y', yd->rxlen - 1);
 			if (start) {
-				g_memmove(yd->rxqueue, start, yd->rxlen - (start - yd->rxqueue));
+				memmove(yd->rxqueue, start, yd->rxlen - (start - yd->rxqueue));
 				yd->rxlen -= start - yd->rxqueue;
 				continue;
 			} else {


### PR DESCRIPTION
This was deprecated in GLib 2.40, but even in 2.16 it was a simple wrapper around `memmove` except for platforms where it didn't exist (but do we really care about those?)