### PR TITLE
This should fix the version update

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -21,6 +21,8 @@ jobs:
           sudo apt-get install -yy --no-install-recommends \
             meson
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          token: ${{ secrets.AUTO_COMMIT_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Update version
         run: |
           meson rewrite kwargs set project / version `date +%Y-%m-%d-${GITHUB_SHA}`


### PR DESCRIPTION
pidgin/retro-prpl main is protected and I missed the documentation for this initially. I created a fine grained access token in the pidgin org and then added it to this repository. It expires in 366 days.

See https://github.com/marketplace/actions/git-auto-commit#push-to-protected-branches for more information.