### PR TITLE
Have meson call a script to determine our version

### DIFF
--- a/get-version.py
+++ b/get-version.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# This script is run by meson to set the project version.
+
+import os
+import subprocess
+
+from datetime import datetime, timezone
+
+
+def run_git(cmd: str) -> str:
+    full_cmd = ['git']
+
+    source_dir = os.environ.get('MESON_SOURCE_ROOT', None)
+    if source_dir is not None:
+        full_cmd.extend(['-C', source_dir])
+
+    full_cmd.extend(cmd.split())
+
+    output = subprocess.check_output(full_cmd)
+
+    return output.decode("utf-8").strip()
+
+
+commit_hash = os.environ.get('GITHUB_SHA', None)
+dt = None
+if commit_hash is not None:
+    iso8601 = run_git('show --no-patch --format=%cI HEAD')
+    dt = datetime.fromisoformat(iso8601)
+else:
+    commit_hash = run_git('describe --dirty --always')
+    dt = datetime.now(timezone.utc)
+
+utc_dt = dt.astimezone(timezone.utc)
+
+print(f'{utc_dt:%Y-%m-%d}-{commit_hash}')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,7 @@
-project('retro-prpl', 'c', meson_version : '>=1.0.0', version : '2025-06-10-f2b45dcd37fe2a9684dd1bc84039e4bfef665e94')
+project(
+  'retro-prpl', 'c',
+  meson_version : '>=1.0.0',
+  version : run_command('get-version.py').stdout().strip())
 
 add_project_arguments('-DHAVE_CONFIG_H', '-DPURPLE_PLUGINS', language: 'c')
 


### PR DESCRIPTION
This adds a script to dynamic determine the version for the project. If GITHUB_SHA is set, the commit date will be used, otherwise the local time will be used. Either time will be converted to UTC to keep the dates consistent.