### PR TITLE
Add Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Runs weekly on Thursday, and groups all updates into a single PR. This should handle updating all the `uses: foo/bar@commit-hash  # v1.2.3` in the actions.