### PR TITLE
Remove the default server for Napster

### DIFF
--- a/napster/napster.c
+++ b/napster/napster.c
@@ -42,7 +42,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define NAP_SERVER "64.124.41.187"
+#define NAP_SERVER ""
 #define NAP_PORT 8888
 
 #define NAPSTER_CONNECT_STEPS 2


### PR DESCRIPTION
This was pointing to some random IP address and they'd probably appreciate it if we don't send people their way..

Trying to connect with an empty server will get stuck trying to connect forever, as it fails dns in libpurple and will need to be fixed there.