### PR TITLE
Oscar: Make client login configurable

### DIFF
--- a/oscar/clientlogin.c
+++ b/oscar/clientlogin.c
@@ -44,35 +44,22 @@
 #include "cipher.h"
 #include "core.h"
 
-#define AIM_LOGIN_HOST "api.screenname.aol.com"
-#define ICQ_LOGIN_HOST "api.login.icq.net"
-
-#define AIM_API_HOST "api.oscar.aol.com"
-#define ICQ_API_HOST "api.icq.net"
-
-#define CLIENT_LOGIN_PAGE "/auth/clientLogin"
-#define START_OSCAR_SESSION_PAGE "/aim/startOSCARSession"
-
-#define HTTPS_FORMAT_URL(host, page) "https://" host page
-
-static const gchar *client_login_urls[] = {
-	HTTPS_FORMAT_URL(AIM_LOGIN_HOST, CLIENT_LOGIN_PAGE),
-	HTTPS_FORMAT_URL(ICQ_LOGIN_HOST, CLIENT_LOGIN_PAGE),
-};
-
-static const gchar *start_oscar_session_urls[] = {
-	HTTPS_FORMAT_URL(AIM_API_HOST, START_OSCAR_SESSION_PAGE),
-	HTTPS_FORMAT_URL(ICQ_API_HOST, START_OSCAR_SESSION_PAGE),
-};
+void
+build_client_login_urls(OscarData *od, const char *api_server_url) {
+	od->client_login_url = g_build_path("/", api_server_url,
+	                                    "/auth/clientLogin", NULL);
+	od->start_oscar_session_url = g_build_path("/", api_server_url,
+	                                           "/aim/startOSCARSession", NULL);
+}
 
 static const gchar *get_client_login_url(OscarData *od)
 {
-	return client_login_urls[od->icq ? 1 : 0];
+	return od->client_login_url;
 }
 
 static const gchar *get_start_oscar_session_url(OscarData *od)
 {
-	return start_oscar_session_urls[od->icq ? 1 : 0];
+	return od->start_oscar_session_url;
 }
 
 static const char *get_client_key(OscarData *od)

--- a/oscar/oscar.c
+++ b/oscar/oscar.c
@@ -787,7 +787,23 @@ oscar_login(PurpleAccount *account)
 	 * clientLogin is not enabled.
 	 */
 	if (purple_strequal(login_type, OSCAR_CLIENT_LOGIN)) {
+		const char *api_server_url = NULL;
+
 		/* Note: Actual server/port configuration is ignored here */
+
+		api_server_url = purple_account_get_string(account, "api-server-url",
+		                                           NULL);
+
+		if(api_server_url == NULL) {
+			purple_connection_error_reason(
+				gc,
+				PURPLE_CONNECTION_ERROR_INVALID_SETTINGS,
+				_("You required client authentication but did not provide an "
+				  "API Server URL."));
+			return;
+		}
+
+		build_client_login_urls(od, api_server_url);
 		send_client_login(od, purple_account_get_username(account));
 	} else if (purple_strequal(login_type, OSCAR_KERBEROS_LOGIN)) {
 		const char *server;
@@ -5800,13 +5816,13 @@ void oscar_init(PurplePlugin *plugin, gboolean is_icq)
 		NULL
 	};
 	static const gchar *icq_login_keys[] = {
-		N_("clientLogin"),
 		N_("MD5-based"),
+		N_("clientLogin"),
 		NULL
 	};
 	static const gchar *icq_login_values[] = {
-		OSCAR_CLIENT_LOGIN,
 		OSCAR_MD5_LOGIN,
+		OSCAR_CLIENT_LOGIN,
 		NULL
 	};
 	const gchar **login_keys;
@@ -5819,6 +5835,9 @@ void oscar_init(PurplePlugin *plugin, gboolean is_icq)
 	prpl_info->protocol_options = g_list_append(prpl_info->protocol_options, option);
 
 	option = purple_account_option_int_new(_("Port"), "port", OSCAR_DEFAULT_LOGIN_PORT);
+	prpl_info->protocol_options = g_list_append(prpl_info->protocol_options, option);
+
+	option = purple_account_option_string_new(_("API Server URL"), "api-server-url", NULL);
 	prpl_info->protocol_options = g_list_append(prpl_info->protocol_options, option);
 
 	for (i = 0; encryption_keys[i]; i++) {

--- a/oscar/oscar.h
+++ b/oscar/oscar.h
@@ -340,6 +340,9 @@ struct _OscarData
 	gboolean icq;
 	guint getblisttimer;
 
+	char *client_login_url;
+	char *start_oscar_session_url;
+
 	struct {
 		guint maxwatchers; /* max users who can watch you */
 		guint maxbuddies; /* max users you can watch */
@@ -493,6 +496,7 @@ int aim_send_login(OscarData *od, FlapConnection *conn, const char *bn, const ch
 /**
  * Only used when connecting with clientLogin.
  */
+void build_client_login_urls(OscarData *od, const char *api_server_url);
 void send_client_login(OscarData *od, const char *username);
 
 /**

--- a/oscar/oscar_data.c
+++ b/oscar/oscar_data.c
@@ -100,6 +100,8 @@ oscar_data_destroy(OscarData *od)
 	aim_cleansnacs(od, -1);
 
 	/* Only used when connecting with clientLogin */
+	g_free(od->client_login_url);
+	g_free(od->start_oscar_session_url);
 	if (od->url_data != NULL)
 		purple_util_fetch_url_cancel(od->url_data);
 


### PR DESCRIPTION
In the past there was only one source for client login but that source is now gone and the clone servers can be many things. This adds a new account setting to set the client login url as it could be http or https and could run on another port even if it is on the same host as the connect server.

I only compiled this and verified it ran as I don't have a server that has client login support available to me.

I also defaulted ICQ to using MD5 auth as well which we did for AIM a long time ago.

Fixes #72 
