### PR TITLE
Actions: update all of the external actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@60168efe1c415ce0f5521ea06d5c2062adbeed1b  # v3.28.17
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           languages: c-cpp
 
@@ -40,4 +40,4 @@ jobs:
           ninja -C build turtles
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b  # v3.28.17
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -27,7 +27,7 @@ jobs:
             libpurple-dev \
             meson
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Meson build
         run: meson setup build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
             libgadu-dev \
             libmeanwhile-dev
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Meson build
         run: meson setup build
@@ -49,7 +49,7 @@ jobs:
       - name: Install build results
         run: DESTDIR=$PWD/dist ninja -C build install
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: "Linux with ${{ matrix.dependencies }} dependencies"
           path: ./dist

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           brew install libgadu
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Meson build
         run: meson setup build
@@ -42,7 +42,7 @@ jobs:
       - name: Install build results
         run: DESTDIR=$PWD/dist ninja -C build install
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: "macOS with ${{ matrix.dependencies }} dependencies"
           path: ./dist

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -22,7 +22,7 @@ jobs:
             gettext \
             libpurple-dev \
             meson
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Meson build
         run: meson setup build

--- a/.github/workflows/win32-cross.yml
+++ b/.github/workflows/win32-cross.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Make cross directory
         run: mkdir -p $RUNNER_TEMP
@@ -54,7 +54,7 @@ jobs:
 
       - name: Load Pidgin from cache
         id: pidgin-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/pidgin
           key: pidgin-${{ env.PIDGIN_VERSION }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Load Win32 deps from cache
         id: win32-cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/win32-dev
           key: win32-dev
@@ -117,7 +117,7 @@ jobs:
 
       - name: archive
         if: ${{ !env.ACT }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
             name: "Win32 cross compiled"
             path: |


### PR DESCRIPTION
This just pulls in the latest versions of everything. Transifex did not have any updates.