### PR TITLE
Fix FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: [imfreedom.org/donate]
+custom: ["https://imfreedom.org/donate/"]


### PR DESCRIPTION
Schema-less URLs end up relative to github.com/pidgin so this links directly to our donate page and avoids additional redirects.