### PR TITLE
OSCAR: Error out early on an empty api url

### DIFF
--- a/oscar/oscar.c
+++ b/oscar/oscar.c
@@ -794,7 +794,7 @@ oscar_login(PurpleAccount *account)
 		api_server_url = purple_account_get_string(account, "api-server-url",
 		                                           NULL);
 
-		if(api_server_url == NULL) {
+		if(api_server_url == NULL || api_server_url[0] == '\0') {
 			purple_connection_error_reason(
 				gc,
 				PURPLE_CONNECTION_ERROR_INVALID_SETTINGS,


### PR DESCRIPTION
Previously we just checked for NULL but the account setting can end up being an empty string as well.

Testing:

Set an AIM account to use client login and made sure the api url was empty and verified that I got a "api server url not specified" error.