### PR TITLE
Depend on meson 1.4.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,9 @@ jobs:
             gettext \
             libmeanwhile-dev \
             libpurple-dev \
-            meson
+            ninja-build \
+            python3-pip
+          pip3 install --break-system-packages meson
           meson setup build
           ninja -C build turtles
 

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -25,7 +25,9 @@ jobs:
             codespell \
             gettext \
             libpurple-dev \
-            meson
+            ninja-build \
+            python3-pip
+          pip3 install --break-system-packages meson
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,9 @@ jobs:
             build-essential \
             gettext \
             libpurple-dev \
-            meson
+            ninja-build \
+            python3-pip
+          pip3 install --break-system-packages meson
 
       - name: Install external dependencies
         if: matrix.dependencies == 'external'
@@ -50,6 +52,7 @@ jobs:
         run: DESTDIR=$PWD/dist ninja -C build install
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: ${{ !env.ACT }}
         with:
           name: "Linux with ${{ matrix.dependencies }} dependencies"
           path: ./dist

--- a/.github/workflows/transifex.yml
+++ b/.github/workflows/transifex.yml
@@ -21,7 +21,9 @@ jobs:
             codespell \
             gettext \
             libpurple-dev \
-            meson
+            ninja-build \
+            python3-pip
+          pip3 install --break-system-packages meson
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Meson build
@@ -31,6 +33,7 @@ jobs:
         run: ninja -C build retro-prpl-pot
 
       - name: Upload pot file
+        if: ${{ !env.ACT }}
         uses: transifex/cli-action@584fd205cbe598773b5a81ce711fa44842678189  # v2
         with:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}

--- a/.github/workflows/win32-cross.yml
+++ b/.github/workflows/win32-cross.yml
@@ -49,8 +49,10 @@ jobs:
           sudo apt install -yy --no-install-recommends \
             codespell \
             gcc-mingw-w64-i686-win32 \
-            meson \
-            pkg-config
+            ninja-build \
+            pkg-config \
+            python3-pip
+          pip3 install --break-system-packages meson
 
       - name: Load Pidgin from cache
         id: pidgin-cache

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'retro-prpl', 'c',
   version : run_command('version.py', 'get-version', check : true).stdout().strip(),
-  meson_version : '>=1.1.0')
+  meson_version : '>=1.4.0')
 
 meson.add_dist_script('version.py', 'set-dist', meson.project_version())
 


### PR DESCRIPTION
This version added the MESONREWRITE environment variable that we depend on.

I changed all the Ubuntu based images to install Meson from pip because ACT (the local github action runner) doesn't have a Ubuntu 26.04 image and I wanted to be able to test locally and in the future.