### PR TITLE
Fix the i18n workflow under ACT

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -27,6 +27,13 @@ jobs:
             libpurple-dev \
             meson
 
+      - name: Add en_US.UTF-8 locale for ACT
+        if: ${{ env.ACT }}
+        run: |
+          echo locales locales/default_environment_locale select en_US.UTF-8 | debconf-set-selections
+          echo locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8 | debconf-set-selections
+          sudo apt-get install locales
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Setup Meson build


### PR DESCRIPTION
The ACT ubuntu-latest image doesn't have the en_US.UTF-8 locale generated which caused our check to fail. This now installs it in the build if running under ACT.