### PR TITLE
Add a tag parameter to the release action

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           artifacts: build/meson-dist/retro-prpl-${{steps.version.outputs.VERSION }}*
           name: ${{ steps.version.outputs.VERSION }}
+          tag: ${{ steps.version.outputs.VERSION }}
           allowUpdates: true
 
       - name: Create Attestation


### PR DESCRIPTION
Apparently a tag is required so just use our version.