### PR TITLE
Fix permissions for attestations

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -10,7 +10,9 @@ jobs:
     name: release dist tarball
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
+      attestations: write
 
     steps:
       - name: Prepare build environment


### PR DESCRIPTION
Ran via act as a sanity check. But just copied the permissions from https://github.com/EionRobb/purple-teams/blob/master/.github/workflows/linux.yml.